### PR TITLE
imageScope should be called documentScope

### DIFF
--- a/server/models/image.model.js
+++ b/server/models/image.model.js
@@ -37,7 +37,7 @@ module.exports = function(mongoose) {
   Schema.statics = {
     collectionName: modelName,
     routeOptions: {
-      imageScope: {
+      documentScope: {
         rootScope: ['root']
       },
       authorizeImageCreator: true,


### PR DESCRIPTION
The routeOptions should have a property documentScope not imageScope (according to the rest-hapi documentation)